### PR TITLE
Update waterdynamics.py

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -54,3 +54,4 @@ The rules for this file:
 
 **2024**
 - Fiona Naughton <@fiona-naughton>
+- Rodolphe Pollet <@rodpollet>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,10 @@ The rules for this file:
 
 ### Authors
 - fiona-naughton
+- rodpollet
 
 ### Added
+- first-order Legendre polynomial for water orientation relaxation analysis
 
 ### Fixed
 

--- a/waterdynamics/tests/test_waterdynamics.py
+++ b/waterdynamics/tests/test_waterdynamics.py
@@ -43,7 +43,7 @@ def universe():
 
 def test_WaterOrientationalRelaxation(universe):
     wor = waterdynamics.WaterOrientationalRelaxation(
-        universe, SELECTION1, 0, 5, 2)
+        universe, SELECTION1, 0, 5, 2, order=2)
     wor.run()
     assert_almost_equal(wor.timeseries[1][2], 0.35887,
                         decimal=5)
@@ -51,7 +51,21 @@ def test_WaterOrientationalRelaxation(universe):
 
 def test_WaterOrientationalRelaxation_zeroMolecules(universe):
     wor_zero = waterdynamics.WaterOrientationalRelaxation(
-        universe, SELECTION2, 0, 5, 2)
+        universe, SELECTION2, 0, 5, 2, order=2)
+    wor_zero.run()
+    assert_almost_equal(wor_zero.timeseries[1], (0.0, 0.0, 0.0))
+
+def test_WaterOrientationalRelaxation(universe):
+    wor = waterdynamics.WaterOrientationalRelaxation(
+        universe, SELECTION1, 0, 5, 2, order=1)
+    wor.run()
+    assert_almost_equal(wor.timeseries[1][2], 0.71486,
+                        decimal=5)
+
+
+def test_WaterOrientationalRelaxation_zeroMolecules(universe):
+    wor_zero = waterdynamics.WaterOrientationalRelaxation(
+        universe, SELECTION2, 0, 5, 2, order=1)
     wor_zero.run()
     assert_almost_equal(wor_zero.timeseries[1], (0.0, 0.0, 0.0))
 

--- a/waterdynamics/tests/test_waterdynamics.py
+++ b/waterdynamics/tests/test_waterdynamics.py
@@ -55,7 +55,7 @@ def test_WaterOrientationalRelaxation_zeroMolecules(universe):
     wor_zero.run()
     assert_almost_equal(wor_zero.timeseries[1], (0.0, 0.0, 0.0))
 
-def test_WaterOrientationalRelaxation(universe):
+def test_WaterOrientationalRelaxation_order_1(universe):
     wor = waterdynamics.WaterOrientationalRelaxation(
         universe, SELECTION1, 0, 5, 2, order=1)
     wor.run()

--- a/waterdynamics/tests/test_waterdynamics.py
+++ b/waterdynamics/tests/test_waterdynamics.py
@@ -63,7 +63,7 @@ def test_WaterOrientationalRelaxation_order_1(universe):
                         decimal=5)
 
 
-def test_WaterOrientationalRelaxation_zeroMolecules(universe):
+def test_WaterOrientationalRelaxation_order_1_zeroMolecules(universe):
     wor_zero = waterdynamics.WaterOrientationalRelaxation(
         universe, SELECTION2, 0, 5, 2, order=1)
     wor_zero.run()


### PR DESCRIPTION
Added first-order Legendre polynomial option


<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - a new argument (order) can be set to 1 or 2 (default) to choose between first-order Legendre polynomial (just x) or second-order Legendre polynomial (1/2 (3x<sup>2</sup>-1)) 
 - lg1 function created
 -  exception raised if order not equal to 1 or 2


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced?
