### PR TITLE
Remove x86_64 env build pin

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -56,7 +56,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
         environment-file: devtools/conda-envs/test_env.yaml
         add-pip-as-python-dependency: true
-        architecture: x64
 
         miniforge-variant: Mambaforge
         use-mamba: true

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -10,5 +10,7 @@ dependencies:
 
   - mdanalysis-sphinx-theme >=1.0.1
   - sphinxcontrib-bibtex
+  # Temporary pin whilst we don't support numpy 2.0 upstream
+  - numpy <2.0
     # Pip-only installs
   #- pip:


### PR DESCRIPTION
See: https://github.com/MDAnalysis/cookiecutter-mdakit/pull/134


<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

Fixes #

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - 
 - 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
